### PR TITLE
Add eslint-plugin-import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/base.js
+++ b/base.js
@@ -7,6 +7,9 @@ module.exports = {
     sourceType: "module"
   },
   extends: "eslint:recommended",
+  plugins: [
+    "import"
+  ],
   rules: {
     "accessor-pairs": "error",
     "array-bracket-spacing": ["error", "never"],
@@ -285,6 +288,37 @@ module.exports = {
       {
         exceptRange: true
       }
-    ]
+    ],
+    // Checks
+
+    // Ensure imports point to files/modules that can be resolved
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md
+    "import/no-unresolved": ["error", { commonjs: true, caseSensitive: true }],
+    // Ensure named imports coupled with named exports
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/named.md#when-not-to-use-it
+    "import/named": "error",
+    // Ensure a default export is present, given a default import.
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/default.md
+    "import/default": "error",
+    // Ensure imported namespaces contain dereferenced properties as they are dereferenced.
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/namespace.md
+    "import/namespace": "error",
+    // Forbid webpack loader syntax in imports
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md
+    "import/no-webpack-loader-syntax": "error",
+    // Report any invalid exports, i.e. re-export of the same name
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/export.md
+    "import/export": "error",
+    // Style
+
+    // Report any imports that come after non-import statements.
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/first.md
+    "import/first": "error",
+    // Ensure all exports appear after other statements
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/exports-last.md
+    "import/exports-last": "error",
+    // Report repeated import of the same module in multiple places
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md
+    "import/no-duplicates": "error"
   }
 };

--- a/base.js
+++ b/base.js
@@ -316,6 +316,9 @@ module.exports = {
         "import/first": "error",
         // Report repeated import of the same module in multiple places
         // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md
-        "import/no-duplicates": "error"
+        "import/no-duplicates": "error",
+        // Ensure all exports appear after other statements
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/exports-last.md
+        "import/exports-last": "error"
     }
 };

--- a/base.js
+++ b/base.js
@@ -295,7 +295,7 @@ module.exports = {
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md
     "import/no-unresolved": ["error", { commonjs: true, caseSensitive: true }],
     // Ensure named imports coupled with named exports
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/named.md#when-not-to-use-it
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/named.md
     "import/named": "error",
     // Ensure a default export is present, given a default import.
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/default.md
@@ -314,9 +314,6 @@ module.exports = {
     // Report any imports that come after non-import statements.
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/first.md
     "import/first": "error",
-    // Ensure all exports appear after other statements
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/exports-last.md
-    "import/exports-last": "error",
     // Report repeated import of the same module in multiple places
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md
     "import/no-duplicates": "error"

--- a/base.js
+++ b/base.js
@@ -1,321 +1,321 @@
 module.exports = {
-  env: {
-    es6: true
-  },
-  parserOptions: {
-    ecmaVersion: 2017,
-    sourceType: "module"
-  },
-  extends: "eslint:recommended",
-  plugins: [
-    "import"
-  ],
-  rules: {
-    "accessor-pairs": "error",
-    "array-bracket-spacing": ["error", "never"],
-    "array-callback-return": "error",
-    "arrow-body-style": ["warn", "as-needed"],
-    "arrow-parens": ["error", "as-needed"],
-    "arrow-spacing": "error",
-    "block-scoped-var": "error",
-    "block-spacing": "error",
-    "brace-style": [
-      "error",
-      "1tbs",
-      {
-        // Drop this with arrow function support
-        allowSingleLine: true
-      }
+    env: {
+        es6: true
+    },
+    parserOptions: {
+        ecmaVersion: 2017,
+        sourceType: "module"
+    },
+    extends: "eslint:recommended",
+    plugins: [
+        "import"
     ],
-    camelcase: [
-      "error",
-      {
-        // Intercom, Stripe, etc.
-        properties: "never"
-      }
-    ],
-    "capitalized-comments": ["warn"],
-    "class-methods-use-this": "error",
-    "comma-dangle": "error",
-    "comma-spacing": "error",
-    "comma-style": ["error", "last"],
-    complexity: [
-      "warn",
-      {
-        max: 10
-      }
-    ],
-    "computed-property-spacing": ["error", "never"],
-    curly: "error",
-    "default-case": "warn",
-    "dot-location": ["error", "property"],
-    "dot-notation": "error",
-    "eol-last": "off",
-    eqeqeq: "error",
-    "for-direction": "error",
-    "func-style": [
-      "error",
-      "declaration",
-      {
-        allowArrowFunctions: true
-      }
-    ],
-    "generator-star-spacing": "error",
-    "guard-for-in": "error",
-    "handle-callback-err": [
-      "error",
-      "^(e|E)|^.*(Error)"
-    ],
-    "id-blacklist": "error",
-    "id-match": "error",
-    indent: ["error", 4, { SwitchCase: 1 }],
-    "key-spacing": "error",
-    "keyword-spacing": "error",
-    "linebreak-style": ["error", "unix"],
-    "max-depth": "error",
-    "max-len": ["error", {
-        "code": 120,
-        "ignoreComments": true,
-        "ignoreStrings": true,
-        "ignoreTemplateLiterals": true
-    }],
-    "max-nested-callbacks": [
-      "error",
-      {
-          "max": 8
-      }
-    ],
-    "max-statements-per-line": [
-      "error",
-      {
-        max: 1
-      }
-    ],
-    "max-params": [
-      "error",
-      {
-          "max": 4
-      }
-    ],
-    "new-cap": "error",
-    "new-parens": "error",
-    "no-alert": "error",
-    "no-await-in-loop": "error",
-    "no-caller": "error",
-    "no-catch-shadow": "error",
-    "no-confusing-arrow": [
-      "error",
-      {
-        allowParens: true
-      }
-    ],
-    "no-continue": "error",
-    "no-duplicate-imports": "error",
-    "no-else-return": "error",
-    "no-empty-function": "error",
-    "no-eq-null": "error",
-    "no-eval": "error",
-    "no-extend-native": "error",
-    "no-extra-bind": "error",
-    "no-extra-label": "error",
-    "no-fallthrough": "off",
-    "no-floating-decimal": "error",
-    "no-implicit-globals": "error",
-    "no-implied-eval": "error",
-    "no-inner-declarations": ["error", "functions"],
-    "no-invalid-this": "error",
-    "no-iterator": "error",
-    "no-labels": "error",
-    "no-lone-blocks": "error",
-    "no-lonely-if": "error",
-    "no-loop-func": "error",
-    "no-magic-numbers": [
-        "warn",
-        {
-            "ignore": [-1, 0, 1]
-        }
-    ],
-    "no-multi-assign": "error",
-    "no-mixed-requires": "error",
-    "no-multi-spaces": "error",
-    "no-multi-str": "error",
-    "no-multiple-empty-lines": [
-      "error",
-      {
-        max: 1,
-        maxEOF: 1
-      }
-    ],
-    "no-native-reassign": "error",
-    "no-nested-ternary": "error",
-    "no-new": "warn",
-    "no-new-func": "error",
-    "no-new-object": "error",
-    "no-new-require": "error",
-    "no-new-wrappers": "error",
-    "no-octal-escape": "error",
-    "no-param-reassign": "error",
-    "no-path-concat": "error",
-    "no-proto": "error",
-    "no-redeclare": "off",
-    "no-restricted-globals": "error",
-    "no-restricted-imports": "error",
-    "no-restricted-modules": "error",
-    "no-restricted-properties": "error",
-    "no-restricted-syntax": "error",
-    "no-return-assign": "error",
-    "no-return-await": "error",
-    "no-script-url": "error",
-    "no-self-compare": "error",
-    "no-sequences": "error",
-    "no-shadow": [
-      "error",
-      {
-        hoist: "functions"
-      }
-    ],
-    "no-shadow-restricted-names": "error",
-    "no-tabs": "error",
-    "no-template-curly-in-string": "error",
-    "no-throw-literal": "error",
-    "no-trailing-spaces": [
-      "error",
-      {
-        skipBlankLines: false
-      }
-    ],
-    "no-underscore-dangle": [
-      "error",
-      {
-          "allow": ["_id", "__v"]
-      }
-    ],
-    "no-undefined": "error",
-    "no-undef-init": "error",
-    "no-unmodified-loop-condition": "error",
-    "no-unneeded-ternary": "error",
-    "no-unused-vars": [
-      "error",
-      {
-        args: "none"
-      }
-    ],
-    "no-use-before-define": [
-      "error",
-      {
-        functions: false
-      }
-    ],
-    "no-useless-call": "error",
-    "no-useless-computed-key": "error",
-    "no-useless-concat": "warn",
-    "no-useless-escape": "error",
-    "no-useless-rename": "error",
-    "no-useless-return": "error",
-    "no-var": "error",
-    "no-whitespace-before-property": "error",
-    "object-property-newline": [
-      "error",
-      {
-        allowAllPropertiesOnSameLine: true
-      }
-    ],
-    "object-curly-newline": [
-      "error",
-      {
-        minProperties: 5,
-        consistent: true
-      }
-    ],
-    "object-curly-spacing": ["error", "always"],
-    "one-var": [
-      "error",
-      "never"
-    ],
-    "one-var-declaration-per-line": ["error", "initializations"],
-    "operator-assignment": "error",
-    "operator-linebreak": "error",
-    "padded-blocks": ["error", "never"],
-    "prefer-numeric-literals": "error",
-    "prefer-promise-reject-errors": [
-        "error",
-        {
-            "allowEmptyReject": true
-        }
-    ],
-    "quote-props": ["error", "consistent-as-needed"],
-    quotes: [
-      "error",
-      "double",
-      {
-        avoidEscape: true,
-        allowTemplateLiterals: true
-      }
-    ],
-    radix: "error",
-    "require-await": "error",
-    semi: ["error", "always"],
-    "semi-spacing": "error",
-    "semi-style": "error",
-    "space-before-blocks": "error",
-    "space-before-function-paren": [
-      "error",
-      { anonymous: "always", named: "never" }
-    ],
-    "space-in-parens": ["error", "never"],
-    "space-infix-ops": "error",
-    "space-unary-ops": "error", // default parameter issue, See: https://github.com/eslint/eslint/issues/
-    "spaced-comment": "error",
-    strict: ["error", "function"],
-    "template-curly-spacing": ["error", "never"],
-    "template-tag-spacing": "error",
-    "unicode-bom": [
-      "error",
-      "never"
-    ],
-    "valid-jsdoc": "error",
-    "valid-typeof": [
-      "error",
-      {
-          "requireStringLiterals": false
-      }
-    ],
-    "wrap-iife": "error",
-    "yield-star-spacing": "error",
-    yoda: [
-      "error",
-      "never",
-      {
-        exceptRange: true
-      }
-    ],
-    // Checks
+    rules: {
+        "accessor-pairs": "error",
+        "array-bracket-spacing": ["error", "never"],
+        "array-callback-return": "error",
+        "arrow-body-style": ["warn", "as-needed"],
+        "arrow-parens": ["error", "as-needed"],
+        "arrow-spacing": "error",
+        "block-scoped-var": "error",
+        "block-spacing": "error",
+        "brace-style": [
+            "error",
+            "1tbs",
+            {
+                // Drop this with arrow function support
+                allowSingleLine: true
+            }
+        ],
+        "camelcase": [
+            "error",
+            {
+                // Intercom, Stripe, etc.
+                properties: "never"
+            }
+        ],
+        "capitalized-comments": ["warn"],
+        "class-methods-use-this": "error",
+        "comma-dangle": "error",
+        "comma-spacing": "error",
+        "comma-style": ["error", "last"],
+        "complexity": [
+            "warn",
+            {
+                max: 10
+            }
+        ],
+        "computed-property-spacing": ["error", "never"],
+        "curly": "error",
+        "default-case": "warn",
+        "dot-location": ["error", "property"],
+        "dot-notation": "error",
+        "eol-last": "off",
+        "eqeqeq": "error",
+        "for-direction": "error",
+        "func-style": [
+            "error",
+            "declaration",
+            {
+                allowArrowFunctions: true
+            }
+        ],
+        "generator-star-spacing": "error",
+        "guard-for-in": "error",
+        "handle-callback-err": [
+            "error",
+            "^(e|E)|^.*(Error)"
+        ],
+        "id-blacklist": "error",
+        "id-match": "error",
+        "indent": ["error", 4, { SwitchCase: 1 }],
+        "key-spacing": "error",
+        "keyword-spacing": "error",
+        "linebreak-style": ["error", "unix"],
+        "max-depth": "error",
+        "max-len": ["error", {
+            code: 120,
+            ignoreComments: true,
+            ignoreStrings: true,
+            ignoreTemplateLiterals: true
+        }],
+        "max-nested-callbacks": [
+            "error",
+            {
+                max: 8
+            }
+        ],
+        "max-statements-per-line": [
+            "error",
+            {
+                max: 1
+            }
+        ],
+        "max-params": [
+            "error",
+            {
+                max: 4
+            }
+        ],
+        "new-cap": "error",
+        "new-parens": "error",
+        "no-alert": "error",
+        "no-await-in-loop": "error",
+        "no-caller": "error",
+        "no-catch-shadow": "error",
+        "no-confusing-arrow": [
+            "error",
+            {
+                allowParens: true
+            }
+        ],
+        "no-continue": "error",
+        "no-duplicate-imports": "error",
+        "no-else-return": "error",
+        "no-empty-function": "error",
+        "no-eq-null": "error",
+        "no-eval": "error",
+        "no-extend-native": "error",
+        "no-extra-bind": "error",
+        "no-extra-label": "error",
+        "no-fallthrough": "off",
+        "no-floating-decimal": "error",
+        "no-implicit-globals": "error",
+        "no-implied-eval": "error",
+        "no-inner-declarations": ["error", "functions"],
+        "no-invalid-this": "error",
+        "no-iterator": "error",
+        "no-labels": "error",
+        "no-lone-blocks": "error",
+        "no-lonely-if": "error",
+        "no-loop-func": "error",
+        "no-magic-numbers": [
+            "warn",
+            {
+                ignore: [-1, 0, 1]
+            }
+        ],
+        "no-multi-assign": "error",
+        "no-mixed-requires": "error",
+        "no-multi-spaces": "error",
+        "no-multi-str": "error",
+        "no-multiple-empty-lines": [
+            "error",
+            {
+                max: 1,
+                maxEOF: 1
+            }
+        ],
+        "no-native-reassign": "error",
+        "no-nested-ternary": "error",
+        "no-new": "warn",
+        "no-new-func": "error",
+        "no-new-object": "error",
+        "no-new-require": "error",
+        "no-new-wrappers": "error",
+        "no-octal-escape": "error",
+        "no-param-reassign": "error",
+        "no-path-concat": "error",
+        "no-proto": "error",
+        "no-redeclare": "off",
+        "no-restricted-globals": "error",
+        "no-restricted-imports": "error",
+        "no-restricted-modules": "error",
+        "no-restricted-properties": "error",
+        "no-restricted-syntax": "error",
+        "no-return-assign": "error",
+        "no-return-await": "error",
+        "no-script-url": "error",
+        "no-self-compare": "error",
+        "no-sequences": "error",
+        "no-shadow": [
+            "error",
+            {
+                hoist: "functions"
+            }
+        ],
+        "no-shadow-restricted-names": "error",
+        "no-tabs": "error",
+        "no-template-curly-in-string": "error",
+        "no-throw-literal": "error",
+        "no-trailing-spaces": [
+            "error",
+            {
+                skipBlankLines: false
+            }
+        ],
+        "no-underscore-dangle": [
+            "error",
+            {
+                allow: ["_id", "__v"]
+            }
+        ],
+        "no-undefined": "error",
+        "no-undef-init": "error",
+        "no-unmodified-loop-condition": "error",
+        "no-unneeded-ternary": "error",
+        "no-unused-vars": [
+            "error",
+            {
+                args: "none"
+            }
+        ],
+        "no-use-before-define": [
+            "error",
+            {
+                functions: false
+            }
+        ],
+        "no-useless-call": "error",
+        "no-useless-computed-key": "error",
+        "no-useless-concat": "warn",
+        "no-useless-escape": "error",
+        "no-useless-rename": "error",
+        "no-useless-return": "error",
+        "no-var": "error",
+        "no-whitespace-before-property": "error",
+        "object-property-newline": [
+            "error",
+            {
+                allowAllPropertiesOnSameLine: true
+            }
+        ],
+        "object-curly-newline": [
+            "error",
+            {
+                minProperties: 5,
+                consistent: true
+            }
+        ],
+        "object-curly-spacing": ["error", "always"],
+        "one-var": [
+            "error",
+            "never"
+        ],
+        "one-var-declaration-per-line": ["error", "initializations"],
+        "operator-assignment": "error",
+        "operator-linebreak": "error",
+        "padded-blocks": ["error", "never"],
+        "prefer-numeric-literals": "error",
+        "prefer-promise-reject-errors": [
+            "error",
+            {
+                allowEmptyReject: true
+            }
+        ],
+        "quote-props": ["error", "consistent-as-needed"],
+        "quotes": [
+            "error",
+            "double",
+            {
+                avoidEscape: true,
+                allowTemplateLiterals: true
+            }
+        ],
+        "radix": "error",
+        "require-await": "error",
+        "semi": ["error", "always"],
+        "semi-spacing": "error",
+        "semi-style": "error",
+        "space-before-blocks": "error",
+        "space-before-function-paren": [
+            "error",
+            { anonymous: "always", named: "never" }
+        ],
+        "space-in-parens": ["error", "never"],
+        "space-infix-ops": "error",
+        "space-unary-ops": "error", // Default parameter issue, See: https://github.com/eslint/eslint/issues/
+        "spaced-comment": "error",
+        "strict": ["error", "function"],
+        "template-curly-spacing": ["error", "never"],
+        "template-tag-spacing": "error",
+        "unicode-bom": [
+            "error",
+            "never"
+        ],
+        "valid-jsdoc": "error",
+        "valid-typeof": [
+            "error",
+            {
+                requireStringLiterals: false
+            }
+        ],
+        "wrap-iife": "error",
+        "yield-star-spacing": "error",
+        "yoda": [
+            "error",
+            "never",
+            {
+                exceptRange: true
+            }
+        ],
+        // Checks
 
-    // Ensure imports point to files/modules that can be resolved
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md
-    "import/no-unresolved": ["error", { commonjs: true, caseSensitive: true }],
-    // Ensure named imports coupled with named exports
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/named.md
-    "import/named": "error",
-    // Ensure a default export is present, given a default import.
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/default.md
-    "import/default": "error",
-    // Ensure imported namespaces contain dereferenced properties as they are dereferenced.
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/namespace.md
-    "import/namespace": "error",
-    // Forbid webpack loader syntax in imports
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md
-    "import/no-webpack-loader-syntax": "error",
-    // Report any invalid exports, i.e. re-export of the same name
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/export.md
-    "import/export": "error",
-    // Style
+        // Ensure imports point to files/modules that can be resolved
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md
+        "import/no-unresolved": ["error", { commonjs: true, caseSensitive: true }],
+        // Ensure named imports coupled with named exports
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/named.md
+        "import/named": "error",
+        // Ensure a default export is present, given a default import.
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/default.md
+        "import/default": "error",
+        // Ensure imported namespaces contain dereferenced properties as they are dereferenced.
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/namespace.md
+        "import/namespace": "error",
+        // Forbid webpack loader syntax in imports
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-webpack-loader-syntax.md
+        "import/no-webpack-loader-syntax": "error",
+        // Report any invalid exports, i.e. re-export of the same name
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/export.md
+        "import/export": "error",
+        // Style
 
-    // Report any imports that come after non-import statements.
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/first.md
-    "import/first": "error",
-    // Report repeated import of the same module in multiple places
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md
-    "import/no-duplicates": "error"
-  }
+        // Report any imports that come after non-import statements.
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/first.md
+        "import/first": "error",
+        // Report repeated import of the same module in multiple places
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-duplicates.md
+        "import/no-duplicates": "error"
+    }
 };

--- a/browser.js
+++ b/browser.js
@@ -1,73 +1,73 @@
 module.exports = {
-  env: {
-    browser: true
-  },
-  parserOptions: {
-    ecmaFeatures: {
-      jsx: true
-    }
-  },
-  plugins: ["react"],
-  settings: {
-    react: {
-      pragma: "preact"
-    }
-  },
-  extends: "./base.js",
-  rules: {
-      "class-methods-use-this": [
-        "error",
-        {
-            // https://github.com/eslint/eslint/issues/7085#issuecomment-250465391
-            exceptMethods: [
-                "componentDidMount",
-                "componentDidUpdate",
-                "componentWillMount",
-                "componentWillReceiveProps",
-                "componentWillUnmount",
-                "componentWillUpdate",
-                "render",
-                "shouldComponentUpdate"
-            ]
+    env: {
+        browser: true
+    },
+    parserOptions: {
+        ecmaFeatures: {
+            jsx: true
         }
-    ],
-    "no-var": "warn",
-    "react/jsx-curly-spacing": ["error", {"when": "never", "children": true}],
-    "react/jsx-key": "warn",
-    "react/jsx-no-bind": ["error", { ignoreRefs: true }],
-    "react/jsx-no-comment-textnodes": "error",
-    "react/jsx-no-duplicate-props": "error",
-    "react/jsx-no-undef": "error",
-    "react/jsx-uses-react": "error",
-    "react/jsx-uses-vars": "error",
-    "react/no-direct-mutation-state": "error",
-    "react/no-find-dom-node": "error",
-    "react/no-is-mounted": "error",
-    "react/no-string-refs": "error",
-    "react/prefer-es6-class": "error",
-    "react/prefer-stateless-function": "warn",
-    "react/require-render-return": "error",
-    "react/self-closing-comp": ["error", { html: false, component: true }],
-    "jsx-quotes": "error",
-    "react/jsx-closing-bracket-location": ["error", "after-props"],
-    "react/jsx-closing-tag-location": "error",
-    "react/jsx-equals-spacing": "error",
-    "react/jsx-curly-brace-presence": ["error", "never"],
-    "react/jsx-pascal-case": "error",
-    "react/jsx-tag-spacing": ["error", {
-        "closingSlash": "never",
-        "beforeSelfClosing": "never",
-        "afterOpening": "never"
-    }],
-    "react/jsx-wrap-multilines": ["error", {
-        "declaration": "parens-new-line",
-        "assignment": "parens-new-line",
-        "return": "parens-new-line",
-        "arrow": "parens-new-line",
-        "condition": "parens-new-line",
-        "logical": "parens-new-line",
-        "prop": "parens-new-line"
-    }],
-    "react/react-in-jsx-scope": "error"
-  }
+    },
+    plugins: ["react"],
+    settings: {
+        react: {
+            pragma: "preact"
+        }
+    },
+    extends: "./base.js",
+    rules: {
+        "class-methods-use-this": [
+            "error",
+            {
+            // https://github.com/eslint/eslint/issues/7085#issuecomment-250465391
+                exceptMethods: [
+                    "componentDidMount",
+                    "componentDidUpdate",
+                    "componentWillMount",
+                    "componentWillReceiveProps",
+                    "componentWillUnmount",
+                    "componentWillUpdate",
+                    "render",
+                    "shouldComponentUpdate"
+                ]
+            }
+        ],
+        "no-var": "warn",
+        "react/jsx-curly-spacing": ["error", { when: "never", children: true }],
+        "react/jsx-key": "warn",
+        "react/jsx-no-bind": ["error", { ignoreRefs: true }],
+        "react/jsx-no-comment-textnodes": "error",
+        "react/jsx-no-duplicate-props": "error",
+        "react/jsx-no-undef": "error",
+        "react/jsx-uses-react": "error",
+        "react/jsx-uses-vars": "error",
+        "react/no-direct-mutation-state": "error",
+        "react/no-find-dom-node": "error",
+        "react/no-is-mounted": "error",
+        "react/no-string-refs": "error",
+        "react/prefer-es6-class": "error",
+        "react/prefer-stateless-function": "warn",
+        "react/require-render-return": "error",
+        "react/self-closing-comp": ["error", { html: false, component: true }],
+        "jsx-quotes": "error",
+        "react/jsx-closing-bracket-location": ["error", "after-props"],
+        "react/jsx-closing-tag-location": "error",
+        "react/jsx-equals-spacing": "error",
+        "react/jsx-curly-brace-presence": ["error", "never"],
+        "react/jsx-pascal-case": "error",
+        "react/jsx-tag-spacing": ["error", {
+            closingSlash: "never",
+            beforeSelfClosing: "never",
+            afterOpening: "never"
+        }],
+        "react/jsx-wrap-multilines": ["error", {
+            declaration: "parens-new-line",
+            assignment: "parens-new-line",
+            return: "parens-new-line",
+            arrow: "parens-new-line",
+            condition: "parens-new-line",
+            logical: "parens-new-line",
+            prop: "parens-new-line"
+        }],
+        "react/react-in-jsx-scope": "error"
+    }
 };

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 module.exports = {
-  extends: "./base.js",
-  rules: {}
+    extends: "./base.js",
+    rules: {}
 };

--- a/node.js
+++ b/node.js
@@ -1,29 +1,29 @@
 module.exports = {
-  env: {
-    node: true,
-    mocha: true
-  },
-  extends: "./base.js",
-  rules: {
-    //overrides
-    "no-buffer-constructor": "error",
-    "no-console": "off",
-    // additions
-    "handle-callback-err": "error",
-    "no-duplicate-imports": ["error", { includeExports: true }],
-    "no-process-env": "error",
-    "no-process-exit": "error",
-    "no-sync": "error",
-    "object-shorthand": ["error", "always"],
-    "prefer-arrow-callback": ["error", { allowNamedFunctions: true }],
-    "prefer-const": "error",
-    "prefer-destructuring": "error",
-    "prefer-rest-params": "error",
-    "prefer-spread": "error",
-    "prefer-template": "error",
-    "rest-spread-spacing": [
-        "error",
-        "never"
-    ],
-  }
+    env: {
+        node: true,
+        mocha: true
+    },
+    extends: "./base.js",
+    rules: {
+    // Overrides
+        "no-buffer-constructor": "error",
+        "no-console": "off",
+        // Additions
+        "handle-callback-err": "error",
+        "no-duplicate-imports": ["error", { includeExports: true }],
+        "no-process-env": "error",
+        "no-process-exit": "error",
+        "no-sync": "error",
+        "object-shorthand": ["error", "always"],
+        "prefer-arrow-callback": ["error", { allowNamedFunctions: true }],
+        "prefer-const": "error",
+        "prefer-destructuring": "error",
+        "prefer-rest-params": "error",
+        "prefer-spread": "error",
+        "prefer-template": "error",
+        "rest-spread-spacing": [
+            "error",
+            "never"
+        ]
+    }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,368 @@
+{
+  "name": "@zeplin/eslint-config",
+  "version": "1.3.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "doctrine": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+      "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      }
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+      "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+      "requires": {
+        "debug": "2.6.9",
+        "resolve": "1.8.1"
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
+      "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
+      "requires": {
+        "debug": "2.6.9",
+        "pkg-dir": "1.0.0"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.14.0.tgz",
+      "integrity": "sha512-FpuRtniD/AY6sXByma2Wr0TXvXJ4nA/2/04VPlfpmUDPOpOY264x+ILiwnrk/k4RINgDAyFZByxqPUbSQ5YE7g==",
+      "requires": {
+        "contains-path": "0.1.0",
+        "debug": "2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "0.3.2",
+        "eslint-module-utils": "2.2.0",
+        "has": "1.0.3",
+        "lodash": "4.17.11",
+        "minimatch": "3.0.4",
+        "read-pkg-up": "2.0.0",
+        "resolve": "1.8.1"
+      }
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "requires": {
+        "path-exists": "2.1.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w=="
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "load-json-file": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "strip-bom": "3.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "requires": {
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
+      },
+      "dependencies": {
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+        }
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "requires": {
+        "hosted-git-info": "2.7.1",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.5.1",
+        "validate-npm-package-license": "3.0.4"
+      }
+    },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+      "requires": {
+        "p-try": "1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "requires": {
+        "p-limit": "1.3.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "requires": {
+        "error-ex": "1.3.2"
+      }
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "requires": {
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+    },
+    "path-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+      "requires": {
+        "pify": "2.3.0"
+      }
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "pkg-dir": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+      "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+      "requires": {
+        "find-up": "1.1.2"
+      }
+    },
+    "read-pkg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+      "requires": {
+        "load-json-file": "2.0.0",
+        "normalize-package-data": "2.4.0",
+        "path-type": "2.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+      "requires": {
+        "find-up": "2.1.0",
+        "read-pkg": "2.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
+      }
+    },
+    "resolve": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "requires": {
+        "path-parse": "1.0.6"
+      }
+    },
+    "semver": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
+    },
+    "spdx-correct": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.1.tgz",
+      "integrity": "sha512-hxSPZbRZvSDuOvADntOElzJpenIR7wXJkuoUcUtS0erbgt2fgeaoPIYretfKpslMhfFDY4k0MZ2F5CUzhBsSvQ==",
+      "requires": {
+        "spdx-expression-parse": "3.0.0",
+        "spdx-license-ids": "3.0.1"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA=="
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "requires": {
+        "spdx-exceptions": "2.2.0",
+        "spdx-license-ids": "3.0.1"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
+      "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w=="
+    },
+    "strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "requires": {
+        "spdx-correct": "3.0.1",
+        "spdx-expression-parse": "3.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.3.3",
   "description": "Zeplin's homegrown `.eslintrc` as an extensible shared config.",
   "homepage": "https://zeplin.io",
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/zeplin/eslint-config.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zeplin/eslint-config.git"
   },
   "keywords": [
     "eslint",
@@ -18,5 +18,8 @@
   "peerDependencies": {
     "eslint": ">= 4.16",
     "eslint-plugin-react": ">= 7.5"
+  },
+  "dependencies": {
+    "eslint-plugin-import": "^2.14.0"
   }
 }


### PR DESCRIPTION
Includes some static checks that can prevent some mistakes (https://github.com/zeplin/zeplin-webapp/pull/1341) and some styling rules.

For styling rules, I tried to reflect on what we have been currently using without linting. So, I didn't add some rules that we are not currently following but may also consider using, those are:
* Report namespace imports ([`no-namespace`])
* Ensure consistent use of file extension within the import path ([`extensions`])
* Enforce a convention in module import order ([`order`])
* Enforce a newline after import statements ([`newline-after-import`])
* Prefer a default export if module exports a single name ([`prefer-default-export`])
* Limit the maximum number of dependencies a module can have ([`max-dependencies`])
* Forbid unassigned imports ([`no-unassigned-import`])
* Forbid named default exports ([`no-named-default`])
* Forbid default exports ([`no-default-export`])
* Forbid named exports ([`no-named-export`])
* Forbid anonymous values as default exports ([`no-anonymous-default-export`])
* Prefer named exports to be grouped together in a single export declaration ([`group-exports`])
* Enforce a leading comment with the webpackChunkName for dynamic imports ([`dynamic-import-chunkname`])

Personally, I like to see ordered imports 😅

Also, there is this project specific thing that may be useful for webapp:
* Restrict which files can be imported in a given folder ([`no-restricted-paths`]): we can prevent client modules importing nodejs modules in mw

[`no-restricted-paths`]: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-restricted-paths.md
[`no-namespace`]: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-namespace.md
[`extensions`]: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md
[`order`]: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md
[`newline-after-import`]: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/newline-after-import.md
[`prefer-default-export`]: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md
[`max-dependencies`]: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/max-dependencies.md
[`no-unassigned-import`]: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unassigned-import.md
[`no-named-default`]: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-default.md
[`no-anonymous-default-export`]: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-anonymous-default-export.md
[`group-exports`]: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/group-exports.md
[`no-default-export`]: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-default-export.md
[`no-named-export`]: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-named-export.md
[`dynamic-import-chunkname`]: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/dynamic-import-chunkname.md