### PR TITLE
Allow underscores to shadow variables

### DIFF
--- a/base.js
+++ b/base.js
@@ -166,6 +166,7 @@ module.exports = {
         "no-shadow": [
             "error",
             {
+                allow: ["_"],
                 hoist: "functions"
             }
         ],


### PR DESCRIPTION
Proposal to allow underscores to shadow variable names from upper scope. Underscores are used as variable names to depict that we're not even interested in that variable.