### PR TITLE
Turn off `no-undefined`

### DIFF
--- a/base.js
+++ b/base.js
@@ -186,7 +186,7 @@ module.exports = {
                 allow: ["_id", "__v"]
             }
         ],
-        "no-undefined": "error",
+        "no-undefined": "off",
         "no-undef-init": "error",
         "no-unmodified-loop-condition": "error",
         "no-unneeded-ternary": "error",


### PR DESCRIPTION
As such, in ECMAScript 3 it was possible to overwrite the value of `undefined`. While ECMAScript 5 disallows overwriting `undefined`.[link](https://eslint.org/docs/rules/no-undef-init)

Since we cannot overwrite `undefined` we can use `undefined`. In the code base there are some `void 0`s and I think it is less readable than `undefined`. Maybe we can also add rule for `void 0` also. WDYT?